### PR TITLE
WiFiClient - remove timeouts after startClient fw call

### DIFF
--- a/src/WiFiClient.cpp
+++ b/src/WiFiClient.cpp
@@ -61,12 +61,6 @@ int WiFiClient::connect(IPAddress ip, uint16_t port) {
     {
     	ServerDrv::startClient(uint32_t(ip), port, _sock);
 
-    	unsigned long start = millis();
-
-    	// wait 4 second for the connection to close
-    	while (!connected() && millis() - start < 10000)
-    		delay(1);
-
     	if (!connected())
        	{
     		return 0;
@@ -89,12 +83,6 @@ int WiFiClient::connectSSL(IPAddress ip, uint16_t port)
     if (_sock != NO_SOCKET_AVAIL)
     {
       ServerDrv::startClient(uint32_t(ip), port, _sock, TLS_MODE);
-
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
 
       if (!connected())
         {
@@ -119,12 +107,6 @@ int WiFiClient::connectSSL(const char *host, uint16_t port)
     {
       ServerDrv::startClient(host, strlen(host), uint32_t(0), port, _sock, TLS_MODE);
 
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
-
       if (!connected())
         {
         return 0;
@@ -148,12 +130,6 @@ int WiFiClient::connectBearSSL(IPAddress ip, uint16_t port)
     {
       ServerDrv::startClient(uint32_t(ip), port, _sock, TLS_BEARSSL_MODE);
 
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
-
       if (!connected())
         {
         return 0;
@@ -176,12 +152,6 @@ int WiFiClient::connectBearSSL(const char *host, uint16_t port)
     if (_sock != NO_SOCKET_AVAIL)
     {
       ServerDrv::startClient(host, strlen(host), uint32_t(0), port, _sock, TLS_BEARSSL_MODE);
-
-      unsigned long start = millis();
-
-      // wait 4 second for the connection to close
-      while (!connected() && millis() - start < 10000)
-        delay(1);
 
       if (!connected())
         {


### PR DESCRIPTION
startClient is blocking in firmware.
if it timed out it doesn't make sense to wait additional 10 seconds